### PR TITLE
Test the gRPC Server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# grpc-toy
+
+A toy gRPC server written in Rust.
+
+Requires [protoc](https://grpc.io/docs/protoc-installation/) & [grpcurl](https://github.com/fullstorydev/grpcurl).
+
+## Usage
+
+## Start the server
+
+```bash
+$ cargo run
+```
+
+## Send a request
+
+```bash
+grpcurl -plaintext -proto protos/hello.proto -d '{"name": "world"}' localhost:8080 hello.HelloService/SayHello
+```
+
+Reply:
+
+```
+{
+  "reply": "Hello, world!"
+}
+```

--- a/protos/hello.proto
+++ b/protos/hello.proto
@@ -10,7 +10,7 @@ service HelloService {
 
 // Message that contains the string to send
 message HelloRequest {
-  string greeting = 1;
+  string name = 1;
 }
 
 // Message that contains the reply string

--- a/src/hello.rs
+++ b/src/hello.rs
@@ -11,10 +11,10 @@ impl HelloService for HelloServiceImpl {
         &self,
         request: Request<HelloRequest>,
     ) -> Result<Response<HelloReply>, Status> {
-        let greeting = request.into_inner().greeting;
+        let name = request.into_inner().name;
 
         let reply = HelloReply {
-            reply: format!("Hello, {}!", greeting),
+            reply: format!("Hello, {}!", name),
         };
 
         Ok(Response::new(reply))

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let (_, health_service) = tonic_health::server::health_reporter();
 
     // Start the server
-    println!("twote-api running on {}", addr);
+    println!("running on {}", addr);
     Server::builder()
         .add_service(health_service)
         .add_service(hello_service)


### PR DESCRIPTION
# grpc-toy

A toy gRPC server written in Rust.

Requires [protoc](https://grpc.io/docs/protoc-installation/) & [grpcurl](https://github.com/fullstorydev/grpcurl).

## Usage

## Start the server

```bash
$ cargo run
```

## Send a request

```bash
grpcurl -plaintext -proto protos/hello.proto -d '{"name": "world"}' localhost:8080 hello.HelloService/SayHello
```

Reply:

```
{
  "reply": "Hello, world!"
}
```