### PR TITLE
add logging

### DIFF
--- a/src/hello.rs
+++ b/src/hello.rs
@@ -7,10 +7,13 @@ pub struct HelloServiceImpl;
 
 #[tonic::async_trait]
 impl HelloService for HelloServiceImpl {
+    #[tracing::instrument(name = "say_hello", skip(self))]
     async fn say_hello(
         &self,
         request: Request<HelloRequest>,
     ) -> Result<Response<HelloReply>, Status> {
+        tracing::info!("Processing say_hello request");
+
         let name = request.into_inner().name;
 
         let reply = HelloReply {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 use crate::hello::hello_service_server::HelloServiceServer;
 use crate::hello::HelloServiceImpl;
 use tonic::transport::Server;
+use tracing_subscriber::FmtSubscriber;
 
 mod hello;
 
@@ -8,6 +9,11 @@ const ADDR: &str = "0.0.0.0:8080";
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let subscriber = FmtSubscriber::builder()
+        .with_max_level(tracing::Level::INFO)
+        .finish();
+
+    tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
     let addr = ADDR.parse()?;
 
     // Create the services


### PR DESCRIPTION
Use [tracing](https://tokio-rs.github.io/tracing/tracing/) within the server

## Testing

Request:
```
grpcurl -plaintext -proto protos/hello.proto -d '{"name": "world"}' localhost:8080 hello.HelloService/SayHello
```

Server logs:
```
cargo run
...
running on 0.0.0.0:8080
...
2023-09-21T23:43:55.602792Z  INFO say_hello{request=Request { metadata: MetadataMap { headers: {"content-type": "application/grpc", "user-agent": "grpcurl/1.8.7 grpc-go/1.48.0", "te": "trailers"} }, message: HelloRequest { name: "world" }, extensions: Extensions }}: grpc_toy::hello: Processing say_hello request
```